### PR TITLE
Add "ground_resolution" method.

### DIFF
--- a/lib/quadkey.rb
+++ b/lib/quadkey.rb
@@ -5,6 +5,7 @@ module Quadkey
   MAX_LATITUDE = 85.05112878
   MIN_LONGITUDE = -180
   MAX_LONGITUDE = 180
+  EARTH_RADIUS = 6378137
 
   def self.encode(latitude, longitude, precision)
     pixel_x, pixel_y = coordinates_to_pixel(latitude, longitude, precision)
@@ -42,6 +43,11 @@ module Quadkey
 
   def self.map_size(precision)
     256 << precision
+  end
+
+  def self.ground_resolution(latitude, precision)
+    latitude = clip(latitude, MIN_LATITUDE, MAX_LATITUDE);
+    return Math.cos(latitude * Math::PI / 180) * 2 * Math::PI * EARTH_RADIUS / map_size(precision);
   end
 
   def self.coordinates_to_pixel(latitude, longitude, precision)

--- a/spec/quadkey_spec.rb
+++ b/spec/quadkey_spec.rb
@@ -17,6 +17,14 @@ describe Quadkey do
     end
   end
 
+  describe '#ground_resolution' do
+    context 'latitude: 35.6684415, precision: 16' do
+      it '1.9405565642194964' do
+        expect(Quadkey.ground_resolution(35.6684415, 16)).to eq(1.9405565642194964)
+      end
+    end
+  end
+
   describe '#neighbors' do
     context "quadkey: '133002112310301'" do
       it do


### PR DESCRIPTION
I wanted to get the width/height(in meter) of a specific tile, so I request "ground_resolution" method. The logic is the same as GroundResolution in https://docs.microsoft.com/en-us/bingmaps/articles/bing-maps-tile-system?redirectedfrom=MSDN